### PR TITLE
Improved logging

### DIFF
--- a/ble-lock-session.py
+++ b/ble-lock-session.py
@@ -11,10 +11,11 @@ import json
 import configparser
 import argparse
 import shutil
+from contextlib import nullcontext
 
 CONFIG_DIR = os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
 CONFIG_FILE = os.path.join(CONFIG_DIR, "ble-lock-session/config.ini")
-LOGFILE = "/tmp/ble-lock-session.log"
+LOGFILE = os.getenv("BLE_LOCK_LOGFILE","-")
 
 # Function to load the configuration from a JSON file
 def load_config():
@@ -81,7 +82,8 @@ def start(target_address, lock_cmd, unlock_cmd, sleep_time, discover_time):
 
     state = 1
     try:
-        with open(LOGFILE, 'w') as file:
+        open_log = lambda: nullcontext(sys.stdout) if LOGFILE == "-" else open(LOGFILE, 'w')
+        with open_log() as file:
             while True:
                 try:
                     check = bluetooth.lookup_name(target_address, timeout=discover_time)


### PR DESCRIPTION
Hi,

I've made some tweaks to the logging system, in order to run the script in an systemd user unit, with logging to journald rather than a file.

The changes allow the user to pass in the file to be logged to via the `BLE_LOCK_LOGFILE` env var. Defaults to `-`(stdout) but I wouldn't mind changing it back to the tmp file either.